### PR TITLE
Make it work with mobile apps

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,0 +1,25 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "QMQYCKL255.io.robbie.HomeAssistant.dev",
+        "paths": [
+          "/redirect/*"
+        ]
+      },
+      {
+        "appID": "QMQYCKL255.io.robbie.HomeAssistant.beta",
+        "paths": [
+          "/redirect/*"
+        ]
+      },
+      {
+        "appID": "QMQYCKL255.io.robbie.HomeAssistant",
+        "paths": [
+          "/redirect/*"
+        ]
+      }
+    ]
+  }
+}

--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -1,0 +1,42 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "io.homeassistant.companion.android",
+      "sha256_cert_fingerprints": [
+        "11:19:4B:A8:09:B4:2D:DF:0E:1A:7D:EC:68:42:A5:9C:7F:F1:11:9C:54:82:E9:5F:EB:FF:D5:C6:01:4D:AA:5A"
+      ]
+    }
+  },
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "io.homeassistant.companion.android.debug",
+      "sha256_cert_fingerprints": [
+        "11:19:4B:A8:09:B4:2D:DF:0E:1A:7D:EC:68:42:A5:9C:7F:F1:11:9C:54:82:E9:5F:EB:FF:D5:C6:01:4D:AA:5A"
+      ]
+    }
+  },
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "io.homeassistant.companion.android.minimal",
+      "sha256_cert_fingerprints": [
+        "11:19:4B:A8:09:B4:2D:DF:0E:1A:7D:EC:68:42:A5:9C:7F:F1:11:9C:54:82:E9:5F:EB:FF:D5:C6:01:4D:AA:5A"
+      ]
+    }
+  },
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "io.homeassistant.companion.android.minimal.debug",
+      "sha256_cert_fingerprints": [
+        "11:19:4B:A8:09:B4:2D:DF:0E:1A:7D:EC:68:42:A5:9C:7F:F1:11:9C:54:82:E9:5F:EB:FF:D5:C6:01:4D:AA:5A"
+      ]
+    }
+  }
+]

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,5 +1,6 @@
 export const HASS_URL = "hassUrl";
 export const DEFAULT_HASS_URL = "http://homeassistant.local:8123";
+export const MOBILE_URL = "homeassistant://navigate";
 
 export type ParamType = "url" | "string";
 

--- a/src/data/instance_info.ts
+++ b/src/data/instance_info.ts
@@ -1,5 +1,9 @@
-import { HASS_URL } from "../const";
+import { HASS_URL, MOBILE_URL } from "../const";
+import { isMobile } from "./is_mobile";
 
 export const getInstanceUrl = (): string | null => {
+  if (isMobile) {
+    return MOBILE_URL;
+  }
   return localStorage.getItem(HASS_URL);
 };

--- a/src/data/is_mobile.ts
+++ b/src/data/is_mobile.ts
@@ -1,0 +1,3 @@
+import { extractSearchParam } from "../util/search-params";
+
+export const isMobile = extractSearchParam("mobile") === "1";

--- a/src/entrypoints/my-redirect.ts
+++ b/src/entrypoints/my-redirect.ts
@@ -7,6 +7,7 @@ import {
 import { getInstanceUrl } from "../data/instance_info";
 import { Redirect, ParamType } from "../const";
 import { svgPencil } from "../components/svg-pencil";
+import { isMobile } from "../data/is_mobile";
 
 declare global {
   interface Window {
@@ -27,6 +28,8 @@ const checkParamType = (type: ParamType, value: string) => {
 const createRedirectParams = (): string => {
   const redirectParams = window.redirect.params;
   const userParams = extractSearchParamsObject();
+  delete userParams.mobile;
+
   if (!redirectParams && !Object.keys(userParams).length) {
     return "";
   }
@@ -68,6 +71,10 @@ const render = () => {
       <mwc-button>Open Link</mwc-button>
     </a>
   `;
+
+  if (isMobile) {
+    return;
+  }
 
   const layout = document.querySelector(".layout")!;
 


### PR DESCRIPTION
Fix #1

~~Still need to address https://github.com/home-assistant/my.home-assistant.io/issues/1#issuecomment-774758915~~

The iOS and Android apps need to register `https://my.home-assistant.io` as a domain that will be opened by the app.

When the app is opened, they need to append `mobile=1` as a URL param. Note: some urls to my.home-assistant.io will already have URL params, you can't just blindly append `?mobile=1`.

When `mobile=1` passed, the configured Home Assistant instance is ignored and instead is set to `homeassistant://navigate`. See:

https://deploy-preview-4--my-home-assistant.netlify.app/redirect/areas/?mobile=1 

The "Open Link" button will now point at the url `homeassistant://navigate/_my_redirect/areas`. This URL should also be registered to open the mobile app. The app UI should navigate to the url `_my_redirect/areas`. This is a new panel that will handle actually processing the redirect.

Is this something that will work?

CC @home-assistant/ios-developers @home-assistant/android 