### PR TITLE
Remove always redirect option

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,6 @@
   "dependencies": {
     "@braintree/sanitize-url": "^5.0.0",
     "@material/mwc-button": "^0.20.0",
-    "@material/mwc-checkbox": "^0.20.0",
-    "@material/mwc-formfield": "^0.20.0",
     "@material/mwc-textfield": "^0.20.0",
     "lit-element": "^2.4.0"
   }

--- a/src-11ty/redirect-page.html
+++ b/src-11ty/redirect-page.html
@@ -9,7 +9,7 @@ permalink: "redirect/{{ redirect.redirect }}/"
 
 <style>
   .ha-card {
-    min-height: 219px;
+    min-height: 203px;
   }
   my-redirect mwc-formfield {
     display: block;

--- a/src/components/my-url-input.ts
+++ b/src/components/my-url-input.ts
@@ -10,7 +10,7 @@ import {
   internalProperty,
   property,
 } from "lit-element";
-import { ALWAYS_REDIRECT, DEFAULT_HASS_URL } from "../const";
+import { DEFAULT_HASS_URL } from "../const";
 import { fireEvent } from "../util/fire_event";
 
 const HASS_URL = "hassUrl";
@@ -72,7 +72,6 @@ export class MyUrlInputMain extends LitElement {
     const url = `${urlObj.protocol}//${urlObj.host}`;
     try {
       window.localStorage.setItem(HASS_URL, url);
-      window.localStorage.removeItem(ALWAYS_REDIRECT);
     } catch (err) {
       if (value !== DEFAULT_HASS_URL) {
         this._error = "Failed to store your url!";

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,3 +1,2 @@
 export const HASS_URL = "hassUrl";
-export const ALWAYS_REDIRECT = "alwaysRedirect";
 export const DEFAULT_HASS_URL = "http://homeassistant.local:8123";

--- a/src/entrypoints/my-redirect.ts
+++ b/src/entrypoints/my-redirect.ts
@@ -1,7 +1,5 @@
 import { sanitizeUrl } from "@braintree/sanitize-url";
 import "@material/mwc-button";
-import "@material/mwc-checkbox";
-import "@material/mwc-formfield";
 import {
   customElement,
   html,
@@ -14,7 +12,7 @@ import {
   createSearchParam,
   extractSearchParamsObject,
 } from "../util/search-params";
-import { ALWAYS_REDIRECT, DEFAULT_HASS_URL, HASS_URL } from "../const";
+import { DEFAULT_HASS_URL, HASS_URL } from "../const";
 import { svgPencil } from "../components/svg-pencil";
 
 type ParamType = "url" | "string";
@@ -33,10 +31,6 @@ class MyHandleRedirect extends LitElement {
 
   @internalProperty() private _error?: string | TemplateResult;
 
-  @internalProperty() private _alwaysRedirect?: boolean = Boolean(
-    localStorage.getItem(ALWAYS_REDIRECT)
-  );
-
   createRenderRoot() {
     return this;
   }
@@ -45,9 +39,6 @@ class MyHandleRedirect extends LitElement {
     super.connectedCallback();
     if (!this.redirect) {
       return;
-    }
-    if (this._alwaysRedirect) {
-      window.location.assign(this._createRedirectUrl());
     }
   }
 
@@ -75,12 +66,7 @@ class MyHandleRedirect extends LitElement {
           : ""}
       </div>
       <div class="card-actions">
-        <mwc-formfield
-          label="Don't ask again"
-          @change=${this._handleAlwaysRedirectChange}
-        >
-          <mwc-checkbox .checked=${this._alwaysRedirect}></mwc-checkbox>
-        </mwc-formfield>
+        <div></div>
         <a href=${this._createRedirectUrl()}>
           <mwc-button>
             Open Link
@@ -125,23 +111,6 @@ class MyHandleRedirect extends LitElement {
       return value && value === sanitizeUrl(value);
     }
     return false;
-  }
-
-  private _handleAlwaysRedirectChange(ev) {
-    const checked = ev.target.checked;
-    this._error = undefined;
-    try {
-      if (checked) {
-        window.localStorage.setItem(ALWAYS_REDIRECT, "true");
-        this._alwaysRedirect = true;
-      } else {
-        window.localStorage.removeItem(ALWAYS_REDIRECT);
-        this._alwaysRedirect = false;
-      }
-    } catch (err) {
-      this._error = "Could not save your settings";
-      ev.target.checked = !checked;
-    }
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -117,19 +117,6 @@
     "@material/typography" "9.0.0-canary.1c156d69d.0"
     tslib "^1.9.3"
 
-"@material/form-field@=9.0.0-canary.1c156d69d.0":
-  version "9.0.0-canary.1c156d69d.0"
-  resolved "https://registry.yarnpkg.com/@material/form-field/-/form-field-9.0.0-canary.1c156d69d.0.tgz#2f44c9704c8a4aef54376819573f835983686e89"
-  integrity sha512-v1KWGRj4Qf9SESLswtlrdm/B6TmNkQsh5CZSM2xL2ZXe/k/KNgbLgM4ofHJApwW3QWYVBfA8nT/MlIvJJivd9w==
-  dependencies:
-    "@material/base" "9.0.0-canary.1c156d69d.0"
-    "@material/feature-targeting" "9.0.0-canary.1c156d69d.0"
-    "@material/ripple" "9.0.0-canary.1c156d69d.0"
-    "@material/rtl" "9.0.0-canary.1c156d69d.0"
-    "@material/theme" "9.0.0-canary.1c156d69d.0"
-    "@material/typography" "9.0.0-canary.1c156d69d.0"
-    tslib "^1.9.3"
-
 "@material/line-ripple@9.0.0-canary.1c156d69d.0", "@material/line-ripple@=9.0.0-canary.1c156d69d.0":
   version "9.0.0-canary.1c156d69d.0"
   resolved "https://registry.yarnpkg.com/@material/line-ripple/-/line-ripple-9.0.0-canary.1c156d69d.0.tgz#a0b275edbd9a039a1143ec4d8789a29e903c90af"
@@ -162,34 +149,12 @@
     lit-html "^1.1.2"
     tslib "^2.0.1"
 
-"@material/mwc-checkbox@^0.20.0":
-  version "0.20.0"
-  resolved "https://registry.yarnpkg.com/@material/mwc-checkbox/-/mwc-checkbox-0.20.0.tgz#fff9d41cd8a72b39a3c883d1b01230e1a3e462fd"
-  integrity sha512-e7qRFpoTZPeBTU05M/FvGnAalY9fJXtzTIfFXWevpm5xm21zr+5lw4QqJOzN8l8Sj8CwciTZ86GMfKGViBbyuw==
-  dependencies:
-    "@material/mwc-base" "^0.20.0"
-    "@material/mwc-ripple" "^0.20.0"
-    lit-element "^2.3.0"
-    lit-html "^1.1.2"
-    tslib "^2.0.1"
-
 "@material/mwc-floating-label@^0.20.0":
   version "0.20.0"
   resolved "https://registry.yarnpkg.com/@material/mwc-floating-label/-/mwc-floating-label-0.20.0.tgz#da7b77491c0e204ec6322a4bc311090b59ccdd3c"
   integrity sha512-WRl/oIkP6A5mqWu9ykWQZsIXxCGJ+JXr/Ooou8F8kJADWVGYf5DNFXKd6gXq+dxXfDbC6AZHPbp7/WH/vuQVrg==
   dependencies:
     "@material/floating-label" "=9.0.0-canary.1c156d69d.0"
-    lit-html "^1.1.2"
-    tslib "^2.0.1"
-
-"@material/mwc-formfield@^0.20.0":
-  version "0.20.0"
-  resolved "https://registry.yarnpkg.com/@material/mwc-formfield/-/mwc-formfield-0.20.0.tgz#dd3e25778aad624a0d13f5b8a33c95bf1aa3883f"
-  integrity sha512-Rrk2ah5gNHD4O/yYWdwHvH3kGddaZXbdiZPCTpYDlTHG63CMUsAENJy8Fu8ZCC23nxbWfBeejtbB/Da+0VZWig==
-  dependencies:
-    "@material/form-field" "=9.0.0-canary.1c156d69d.0"
-    "@material/mwc-base" "^0.20.0"
-    lit-element "^2.3.0"
     lit-html "^1.1.2"
     tslib "^2.0.1"
 


### PR DESCRIPTION
This option makes things complicated right now. Users will forget that they had it enabled and then don't realize how to turn it off (you can't uncheck the box because you are instantly redirected 😅).

I say we start without it and then move to add it later if we can come up with an improved approach. The websites are so fast now, we might not need it.