### PR TITLE
Clean up templating a bit and show troubleshooting

### DIFF
--- a/src-11ty/_includes/base.html
+++ b/src-11ty/_includes/base.html
@@ -131,14 +131,12 @@ My Home Assistant
       }
 
       .ha-card h1.card-header {
-        margin: 0;
-        padding: 24px 16px 16px;
+        margin: 24px 16px 16px;
         display: block;
       }
 
       .ha-card .card-content {
         padding: 0 16px 16px;
-        margin-top: -8px;
       }
 
       .ha-card .card-content p:last-child {
@@ -150,6 +148,13 @@ My Home Assistant
         display: flex;
         justify-content: space-between;
         align-items: center;
+      }
+      .highlight {
+        padding: 8px 16px;
+        background-color: #fff59d;
+      }
+      .highlight + .card-content {
+        margin-top: 16px;
       }
     </style>
     <script>

--- a/src-11ty/_includes/base.html
+++ b/src-11ty/_includes/base.html
@@ -173,7 +173,7 @@ My Home Assistant
   </head>
   <body>
     <div class="layout">
-      <div class="ha-card">{{ content | safe }}</div>
+      {{ content | safe }}
       <div class="spacer"></div>
       <div class="footer">
         <a href="/">My Home Assistant</a> –

--- a/src-11ty/_includes/base_card_with_hero.html
+++ b/src-11ty/_includes/base_card_with_hero.html
@@ -17,8 +17,10 @@ layout: base
   }
 </style>
 
-<div class="hero">
-  <img src="/images/header.jpg" alt="Decorative header" />
-</div>
+<div class="ha-card">
+  <div class="hero">
+    <img src="/images/header.jpg" alt="Decorative header" />
+  </div>
 
-{{ content | safe }}
+  {{ content | safe }}
+</div>

--- a/src-11ty/create-link.html
+++ b/src-11ty/create-link.html
@@ -1,5 +1,5 @@
 ---
-layout: base_with_hero
+layout: base_card_with_hero
 title: Create a link
 description: Generate links to any place in Home Assistant.
 ---

--- a/src-11ty/faq.html
+++ b/src-11ty/faq.html
@@ -93,7 +93,7 @@ description: Answers to all your questions about My Home Assistant.
   </p>
 </div>
 
-<div class="section-header">What pages are supported?</div>
+<div class="section-header" id="supported-pages">What pages are supported?</div>
 <div class="redirects">
   {% for redirect in redirects %}
   <a

--- a/src-11ty/faq.html
+++ b/src-11ty/faq.html
@@ -1,5 +1,5 @@
 ---
-layout: base_with_hero
+layout: base_card_with_hero
 title: FAQ
 description: Answers to all your questions about My Home Assistant.
 ---
@@ -60,11 +60,17 @@ description: Answers to all your questions about My Home Assistant.
   </p>
 </div>
 
-<div class="section-header">
+<div class="section-header" id="404">
   Why do I get a "404 Not Found" when I open a link?
 </div>
 <div class="card-content">
-  <p>This website requires you to run at least Home Assistant 2021.3.</p>
+  <p>
+    This website requires you to run at least Home Assistant 2021.3 and have the
+    <a href="https://www.home-assistant.io/integrations/my/"
+      >"my" integration</a
+    >
+    enabled.
+  </p>
 </div>
 
 <div class="section-header">
@@ -87,7 +93,7 @@ description: Answers to all your questions about My Home Assistant.
   </p>
 </div>
 
-<div class="section-header" id="supported-pages">What pages are supported?</div>
+<div class="section-header">What pages are supported?</div>
 <div class="redirects">
   {% for redirect in redirects %}
   <a

--- a/src-11ty/index.html
+++ b/src-11ty/index.html
@@ -1,5 +1,5 @@
 ---
-layout: base_with_hero
+layout: base_card_with_hero
 description: Link you to specific pages in your Home Assistant instance.
 ---
 

--- a/src-11ty/index.html
+++ b/src-11ty/index.html
@@ -4,6 +4,9 @@ description: Link you to specific pages in your Home Assistant instance.
 ---
 
 <style>
+  my-url-input {
+    margin-top: 16px;
+  }
   .instance-info {
     display: flex;
     justify-content: space-between;

--- a/src-11ty/redirect-page.html
+++ b/src-11ty/redirect-page.html
@@ -9,7 +9,7 @@ permalink: "redirect/{{ redirect.redirect }}/"
 
 <style>
   .open-link-card {
-    min-height: 158px;
+    min-height: 150px;
     display: flex;
     flex-direction: column;
   }

--- a/src-11ty/redirect-page.html
+++ b/src-11ty/redirect-page.html
@@ -41,12 +41,23 @@ permalink: "redirect/{{ redirect.redirect }}/"
     position: relative;
     bottom: -3px;
   }
+  .troubleshooting {
+    display: none;
+    padding: 8px 16px;
+    background-color: #fff59d;
+  }
 </style>
 
 <div class="ha-card open-link-card">
   <h1 class="card-header">Open page in your Home Assistant?</h1>
   <div class="card-content">
     <p>You've been linked to the page that will {{ redirect.description }}.</p>
+  </div>
+
+  <div class="troubleshooting">
+    It looks like you came back to this page after you clicked the link. If the
+    link didn't work, make sure your instance URL below is correct and check
+    <a href="/faq#404">our troubleshooting steps</a>.
   </div>
 
   <div class="card-actions">

--- a/src-11ty/redirect-page.html
+++ b/src-11ty/redirect-page.html
@@ -41,20 +41,18 @@ permalink: "redirect/{{ redirect.redirect }}/"
     position: relative;
     bottom: -3px;
   }
-  .troubleshooting {
+  .highlight {
     display: none;
-    padding: 8px 16px;
-    background-color: #fff59d;
   }
 </style>
 
 <div class="ha-card open-link-card">
   <h1 class="card-header">Open page in your Home Assistant?</h1>
   <div class="card-content">
-    <p>You've been linked to the page that will {{ redirect.description }}.</p>
+    You've been linked to the page that will {{ redirect.description }}.
   </div>
 
-  <div class="troubleshooting">
+  <div class="highlight">
     It looks like you came back to this page after you clicked the link. If the
     link didn't work, make sure your instance URL below is correct and check
     <a href="/faq#404">our troubleshooting steps</a>.

--- a/src-11ty/redirect-page.html
+++ b/src-11ty/redirect-page.html
@@ -8,7 +8,7 @@ permalink: "redirect/{{ redirect.redirect }}/"
 ---
 
 <style>
-  .ha-card {
+  .open-link-card {
     min-height: 158px;
     display: flex;
     flex-direction: column;
@@ -43,15 +43,19 @@ permalink: "redirect/{{ redirect.redirect }}/"
   }
 </style>
 
-<h1 class="card-header">Open page in your Home Assistant?</h1>
-<div class="card-content">
-  <p>You've been linked to the page that will {{ redirect.description }}.</p>
+<div class="ha-card open-link-card">
+  <h1 class="card-header">Open page in your Home Assistant?</h1>
+  <div class="card-content">
+    <p>You've been linked to the page that will {{ redirect.description }}.</p>
+  </div>
+
+  <div class="card-actions">
+    <div></div>
+    <div class="fake-button open-link">OPEN LINK</div>
+  </div>
 </div>
 
-<div class="card-actions">
-  <div></div>
-  <div class="fake-button open-link">OPEN LINK</div>
-</div>
+<div class="instance-footer"></div>
 
 <script>
   window.redirect = {{ redirect | stringify }};

--- a/src/entrypoints/my-index.ts
+++ b/src/entrypoints/my-index.ts
@@ -51,17 +51,18 @@ class MyIndex extends LitElement {
   protected render(): TemplateResult {
     if (this._updatingUrl) {
       return html`
+        ${changeRequestedFromRedirect && !this._instanceUrl
+          ? html`
+              <div class="highlight">
+                You are seeing this page because you have been linked to a page
+                in your Home&nbsp;Assistant instance but have not configured
+                My&nbsp;Home&nbsp;Assistant. Enter the URL of your
+                Home&nbsp;Assistant instance to continue.
+              </div>
+            `
+          : ""}
         <div class="card-content">
-          ${changeRequestedFromRedirect && !this._instanceUrl
-            ? html`
-                <p>
-                  You are seeing this page because you have been linked to a
-                  page in your Home&nbsp;Assistant instance but have not
-                  configured My&nbsp;Home&nbsp;Assistant. Enter the URL of your
-                  Home&nbsp;Assistant instance to continue.
-                </p>
-              `
-            : !this._instanceUrl
+          ${!this._instanceUrl && !changeRequestedFromRedirect
             ? html`
                 <p>
                   Configure My&nbsp;Home&nbsp;Assistant by entering the URL of

--- a/src/entrypoints/my-index.ts
+++ b/src/entrypoints/my-index.ts
@@ -64,10 +64,8 @@ class MyIndex extends LitElement {
         <div class="card-content">
           ${!this._instanceUrl && !changeRequestedFromRedirect
             ? html`
-                <p>
-                  Configure My&nbsp;Home&nbsp;Assistant by entering the URL of
-                  your Home&nbsp;Assistant instance.
-                </p>
+                Configure My&nbsp;Home&nbsp;Assistant by entering the URL of
+                your Home&nbsp;Assistant instance.
               `
             : ""}
 

--- a/src/entrypoints/my-redirect.ts
+++ b/src/entrypoints/my-redirect.ts
@@ -76,20 +76,13 @@ const render = () => {
     return;
   }
 
-  const layout = document.querySelector(".layout")!;
-
-  let changeInstanceEl = document.querySelector(".instance-footer");
-  if (!changeInstanceEl) {
-    changeInstanceEl = document.createElement("div");
-    changeInstanceEl.classList.add("instance-footer");
-  }
+  let changeInstanceEl = document.querySelector(".instance-footer")!;
   changeInstanceEl.innerHTML = `
     <b>Your instance URL:</b> ${instanceUrl}
     <a href="/?change=1">
       ${svgPencil}
     </a>
   `;
-  layout.insertBefore(changeInstanceEl, layout.querySelector(".spacer"));
 };
 
 render();

--- a/src/entrypoints/my-redirect.ts
+++ b/src/entrypoints/my-redirect.ts
@@ -46,7 +46,9 @@ const createRedirectParams = (): string => {
   return `?${createSearchParam(userParams)}`;
 };
 
-const render = () => {
+let changingInstance = false;
+
+const render = (showTroubleshooting: boolean) => {
   const instanceUrl = getInstanceUrl();
 
   if (instanceUrl === null) {
@@ -83,13 +85,26 @@ const render = () => {
       ${svgPencil}
     </a>
   `;
+  changeInstanceEl.querySelector("a")!.addEventListener("click", () => {
+    changingInstance = true;
+  });
+
+  // When we were changing the instance, we're not going to mess with troubleshooting.
+  if (changingInstance) {
+    changingInstance = false;
+    return;
+  }
+
+  (document.querySelector(
+    ".troubleshooting"
+  ) as HTMLDivElement).style.display = showTroubleshooting ? "block" : "none";
 };
 
-render();
+render(false);
 
 // For Safari/FF to handle history.back() after update instance URL
 window.onpageshow = (event) => {
   if (event.persisted) {
-    render();
+    render(true);
   }
 };

--- a/src/entrypoints/my-redirect.ts
+++ b/src/entrypoints/my-redirect.ts
@@ -52,6 +52,7 @@ const render = (showTroubleshooting: boolean) => {
   const instanceUrl = getInstanceUrl();
 
   if (instanceUrl === null) {
+    changingInstance = true;
     setTimeout(() => document.location.assign("/?change=1"), 100);
     return;
   }
@@ -96,7 +97,7 @@ const render = (showTroubleshooting: boolean) => {
   }
 
   (document.querySelector(
-    ".troubleshooting"
+    ".highlight"
   ) as HTMLDivElement).style.display = showTroubleshooting ? "block" : "none";
 };
 


### PR DESCRIPTION
Remove the `ha-card` from the base template, to allow simplifying the redirect JS.

This PR was originally going to include a troubleshooting text on the redirect page based on if `persisted` was set to `true` in the `pageshow` event. ~~This plan was discarded because a) browsers don't fire this reliably and b) we use `history.back()` after changing instance URL so we get a `persisted=true` then too.~~

I found a way to make it work by setting a var before navigating away.

Note that this feature only seems to reliably work on FF and Safari.

![image](https://user-images.githubusercontent.com/1444314/109455569-ce577880-7a0b-11eb-8a01-c70f4d992cb8.png)

