### PR TITLE
Hide footer in mobile apps

### DIFF
--- a/src/entrypoints/my-redirect.ts
+++ b/src/entrypoints/my-redirect.ts
@@ -76,6 +76,8 @@ const render = (showTroubleshooting: boolean) => {
   `;
 
   if (isMobile) {
+    (document.querySelector(".footer") as HTMLDivElement).style.display =
+      "none";
     return;
   }
 


### PR DESCRIPTION
If you use the links in the footer in the mobile app we no longer know that you are on mobile, causing problems.

We could fix those on every page, but I don't think we really need the footer on the mobile apps?