### PR TITLE
Allow adding params for create-link

### DIFF
--- a/src/entrypoints/my-create-link.ts
+++ b/src/entrypoints/my-create-link.ts
@@ -143,6 +143,8 @@ ${badgeHTML}</textarea
         `mwc-textfield[data-key=${key}]`
       ) as TextField;
 
+      inputEl.value = passedInData[key];
+
       if (msg) {
         inputEl.updateComplete.then(() => {
           inputEl.setCustomValidity(msg);
@@ -150,7 +152,6 @@ ${badgeHTML}</textarea
         });
       } else {
         paramValues[key] = passedInData[key];
-        inputEl.value = passedInData[key];
       }
     }
 

--- a/src/entrypoints/my-create-link.ts
+++ b/src/entrypoints/my-create-link.ts
@@ -1,7 +1,6 @@
 import "@material/mwc-button";
 import "@material/mwc-select";
 import "@material/mwc-textfield";
-import { sanitizeUrl } from "@braintree/sanitize-url";
 import { repeat } from "lit-html/directives/repeat.js";
 import { unsafeHTML } from "lit-html/directives/unsafe-html.js";
 import copy from "clipboard-copy";
@@ -13,9 +12,13 @@ import {
   TemplateResult,
 } from "lit-element";
 import redirects from "../../redirect.json";
-import { createSearchParam, extractSearchParam } from "../util/search-params";
+import {
+  createSearchParam,
+  extractSearchParamsObject,
+} from "../util/search-params";
 import type { Button } from "@material/mwc-button";
-import { Redirect } from "../const";
+import { ParamType, Redirect } from "../const";
+import { validateParam } from "../util/validate";
 
 const prettify = (key: string) =>
   capitalizeFirst(key.replace("_", " ").replace("url", "URL"));
@@ -23,26 +26,13 @@ const prettify = (key: string) =>
 const capitalizeFirst = (text: string) =>
   text.charAt(0).toUpperCase() + text.slice(1);
 
-const validateUrl = (value: string) => {
-  if (value.indexOf("://") === -1) {
-    return "Please enter your full URL, including the protocol part (https://).";
-  }
-  try {
-    new URL(value);
-  } catch (err) {
-    return "Invalid URL.";
-  }
-  if (value !== sanitizeUrl(value)) {
-    return "Invalid URL.";
-  }
-  return undefined;
-};
-
 let initialRedirect;
+const passedInData = extractSearchParamsObject();
 {
-  const redirect = extractSearchParam("redirect");
-  if (redirect) {
-    initialRedirect = redirects.find((info) => info.redirect === redirect);
+  if (passedInData.redirect) {
+    initialRedirect = redirects.find(
+      (info) => info.redirect === passedInData.redirect
+    );
   }
   if (!initialRedirect) {
     initialRedirect = redirects[0];
@@ -52,7 +42,6 @@ let initialRedirect;
 @customElement("my-create-link")
 class MyCreateLink extends LitElement {
   @internalProperty() _redirect: Redirect = initialRedirect;
-
   @internalProperty() _paramsValues = {};
 
   protected createRenderRoot() {
@@ -89,7 +78,7 @@ class MyCreateLink extends LitElement {
             required
             validationMessage="This field is required"
             .label=${prettify(key)}
-            .key=${key}
+            data-key="${key}"
             @input=${this._paramChanged}
           ></mwc-textfield>`
         )}
@@ -137,6 +126,28 @@ ${badgeHTML}</textarea
     `;
   }
 
+  protected firstUpdated(props) {
+    super.firstUpdated(props);
+
+    const paramValues = {};
+
+    for (const [key, paramType] of Object.entries(
+      this._redirect.params || {}
+    )) {
+      if (
+        key in passedInData &&
+        passedInData[key] &&
+        validateParam(paramType as ParamType, passedInData[key]) === undefined
+      ) {
+        paramValues[key] = passedInData[key];
+        (this.querySelector(`*[data-key=${key}]`) as any).value =
+          passedInData[key];
+      }
+    }
+
+    this._paramsValues = paramValues;
+  }
+
   private get isValid() {
     return (
       this._redirect &&
@@ -147,23 +158,26 @@ ${badgeHTML}</textarea
   }
 
   private _itemSelected(ev) {
-    // Not sure why TS is complaining here
+    const newRedirect = redirects[ev.detail.index];
+
+    if (newRedirect.redirect === this._redirect.redirect) {
+      return;
+    }
+
     // @ts-expect-error
-    this._redirect = redirects[ev.detail.index];
+    this._redirect = newRedirect;
     this._paramsValues = {};
   }
 
   private _paramChanged(ev) {
-    const key = ev.currentTarget.key;
+    const key = ev.currentTarget.dataset.key;
     let value = ev.target.value;
 
-    if (this._redirect.params![key] === "url") {
-      const validationMessage = validateUrl(value);
-      if (validationMessage) {
-        ev.currentTarget.setCustomValidity(validationMessage);
-        ev.currentTarget.reportValidity();
-        value = undefined;
-      }
+    const validationMessage = validateParam(this._redirect.params![key], value);
+    if (validationMessage) {
+      ev.currentTarget.setCustomValidity(validationMessage);
+      ev.currentTarget.reportValidity();
+      value = undefined;
     }
 
     if (value) {

--- a/src/entrypoints/my-create-link.ts
+++ b/src/entrypoints/my-create-link.ts
@@ -1,6 +1,7 @@
 import "@material/mwc-button";
 import "@material/mwc-select";
 import "@material/mwc-textfield";
+import type { TextField } from "@material/mwc-textfield";
 import { repeat } from "lit-html/directives/repeat.js";
 import { unsafeHTML } from "lit-html/directives/unsafe-html.js";
 import copy from "clipboard-copy";
@@ -134,14 +135,22 @@ ${badgeHTML}</textarea
     for (const [key, paramType] of Object.entries(
       this._redirect.params || {}
     )) {
-      if (
-        key in passedInData &&
-        passedInData[key] &&
-        validateParam(paramType as ParamType, passedInData[key]) === undefined
-      ) {
+      if (!(key in passedInData) || !passedInData[key]) {
+        continue;
+      }
+      const msg = validateParam(paramType as ParamType, passedInData[key]);
+      const inputEl = this.querySelector(
+        `mwc-textfield[data-key=${key}]`
+      ) as TextField;
+
+      if (msg) {
+        inputEl.updateComplete.then(() => {
+          inputEl.setCustomValidity(msg);
+          inputEl.reportValidity();
+        });
+      } else {
         paramValues[key] = passedInData[key];
-        (this.querySelector(`*[data-key=${key}]`) as any).value =
-          passedInData[key];
+        inputEl.value = passedInData[key];
       }
     }
 

--- a/src/entrypoints/my-redirect.ts
+++ b/src/entrypoints/my-redirect.ts
@@ -1,29 +1,19 @@
-import { sanitizeUrl } from "@braintree/sanitize-url";
 import "@material/mwc-button";
 import {
   createSearchParam,
   extractSearchParamsObject,
 } from "../util/search-params";
 import { getInstanceUrl } from "../data/instance_info";
-import { Redirect, ParamType } from "../const";
+import { Redirect } from "../const";
 import { svgPencil } from "../components/svg-pencil";
 import { isMobile } from "../data/is_mobile";
+import { validateParam } from "../util/validate";
 
 declare global {
   interface Window {
     redirect: Redirect;
   }
 }
-
-const checkParamType = (type: ParamType, value: string) => {
-  if (type === "string") {
-    return true;
-  }
-  if (type === "url") {
-    return value && value === sanitizeUrl(value);
-  }
-  return false;
-};
 
 const createRedirectParams = (): string => {
   const redirectParams = window.redirect.params;
@@ -39,7 +29,7 @@ const createRedirectParams = (): string => {
     throw Error("Wrong parameters");
   }
   Object.entries(redirectParams || {}).forEach(([key, type]) => {
-    if (!userParams[key] || !checkParamType(type, userParams[key])) {
+    if (!userParams[key] || validateParam(type, userParams[key])) {
       throw Error("Wrong parameters");
     }
   });

--- a/src/util/validate.ts
+++ b/src/util/validate.ts
@@ -1,0 +1,36 @@
+import { sanitizeUrl } from "@braintree/sanitize-url";
+import { ParamType } from "../const";
+
+const validateUrl = (value: string) => {
+  if (value.indexOf("://") === -1) {
+    return "Please enter your full URL, including the protocol part (https://).";
+  }
+  try {
+    new URL(value);
+  } catch (err) {
+    return "Invalid URL.";
+  }
+  if (value !== sanitizeUrl(value)) {
+    return "Invalid URL.";
+  }
+  return undefined;
+};
+
+/**
+ * Validate a param.
+ * @returns string with validation error if value is invalid.
+ */
+export const validateParam = (
+  paramType: ParamType,
+  value: string
+): string | undefined => {
+  if (paramType === "string") {
+    return undefined;
+  }
+
+  if (paramType === "url") {
+    return validateUrl(value);
+  }
+
+  return "Unknown param type";
+};


### PR DESCRIPTION
Allow setting params for the create link screen. Only added when they are valid.

Examples:
 - [With valid param](https://deploy-preview-70--my-home-assistant.netlify.app/create-link/?redirect=blueprint_import&blueprint_url=https%3A%2F%2Fgithub.com%2Fhome-assistant%2Fcore%2Fblob%2Fmaster%2Fhomeassistant%2Fcomponents%2Fautomation%2Fblueprints%2Fmotion_light.yaml)
 - [With invalid param](https://deploy-preview-70--my-home-assistant.netlify.app/create-link/?redirect=blueprint_import&blueprint_url=lol%20no%20url)