### PR TITLE
Share -> Create

### DIFF
--- a/src-11ty/_includes/base.html
+++ b/src-11ty/_includes/base.html
@@ -223,7 +223,7 @@ My Home Assistant
       <div class="spacer"></div>
       <div class="footer">
         <a href="/">My Home Assistant</a> –
-        <a href="/create-link/">Share link</a> – <a href="/faq/">FAQ</a> –
+        <a href="/create-link/">Create link</a> – <a href="/faq/">FAQ</a> –
         <a
           href="https://github.com/home-assistant/my.home-assistant.io/issues"
           target="_blank"


### PR DESCRIPTION
Rename in the footer "Share Link" to "Create Link". I think that with the word "Share", people might think that it relates to sharing the _current_ page, not a My link.