### PR TITLE
Rename add-on dashboard with add-on prefix

### DIFF
--- a/redirect.json
+++ b/redirect.json
@@ -1,5 +1,18 @@
 [
   {
+    "redirect": "supervisor_addon",
+    "name": "Add-on: Dashboard",
+    "badge": "add-on",
+    "description": "show the dashboard of a Supervisor add-on",
+    "introduced": "supervisor-2021.02.10",
+    "params": {
+      "addon": "string"
+    },
+    "example": {
+      "addon": "core_samba"
+    }
+  },
+  {
     "redirect": "supervisor_ingress",
     "name": "Add-on: Ingress",
     "badge": "Add-on: Ingress",
@@ -252,19 +265,6 @@
     "badge": "Supervisor Logs",
     "description": "show your Supervisor system logs",
     "introduced": "supervisor-2021.02.12"
-  },
-  {
-    "redirect": "supervisor_addon",
-    "name": "Supervisor: Show add-on",
-    "badge": "add-on",
-    "description": "show the dashboard of a Supervisor add-on",
-    "introduced": "supervisor-2021.02.10",
-    "params": {
-      "addon": "string"
-    },
-    "example": {
-      "addon": "core_samba"
-    }
   },
   {
     "redirect": "supervisor_snapshots",

--- a/src/entrypoints/my-create-link.ts
+++ b/src/entrypoints/my-create-link.ts
@@ -36,7 +36,8 @@ const passedInData = extractSearchParamsObject();
     );
   }
   if (!initialRedirect) {
-    initialRedirect = redirects[0];
+    // Select first one without params so we show the output
+    initialRedirect = redirects.find((info) => info.params === undefined);
   }
 }
 


### PR DESCRIPTION
Renames the `supervisor: add-on` link to `add-on: dashboard` so it sits next to `add-on: ingress`.

Also updates the default selected link to be the first one that has no parameters such that on opening the create link page, it shows directly the buttons.