### PR TITLE
Fix redirecting for configuring instance adding an incorrect slash

### DIFF
--- a/src/entrypoints/my-change-url.ts
+++ b/src/entrypoints/my-change-url.ts
@@ -103,9 +103,10 @@ class MyChangeUrl extends LitElement {
 
     if (changeRequestedFromRedirect) {
       window.location.assign(
-        `/redirect/${decodeURIComponent(changeRequestedFromRedirect)}/`
+        `/redirect/${decodeURIComponent(changeRequestedFromRedirect)}`
       );
     } else {
+      // Shouldn't happen, but keep it as fallback
       history.back();
     }
   }

--- a/src/entrypoints/my-redirect.ts
+++ b/src/entrypoints/my-redirect.ts
@@ -49,13 +49,13 @@ const render = (showTroubleshooting: boolean) => {
     return;
   }
 
+  const changeUrl = `/redirect/_change/?redirect=${encodeURIComponent(
+    window.redirect.redirect + "/" + params
+  )}`;
+
   if (instanceUrl === null) {
     changingInstance = true;
-    document.location.assign(
-      `/redirect/_change/?redirect=${encodeURIComponent(
-        window.redirect.redirect + params
-      )}`
-    );
+    document.location.assign(changeUrl);
     return;
   }
 
@@ -76,7 +76,7 @@ const render = (showTroubleshooting: boolean) => {
   let changeInstanceEl = document.querySelector(".instance-footer")!;
   changeInstanceEl.innerHTML = `
     <b>Your instance URL:</b> ${instanceUrl}
-    <a href="/redirect/_change">
+    <a href="${changeUrl}">
       ${svgPencil}
     </a>
   `;


### PR DESCRIPTION
Fixed that when we got redirected to the change password page because we hadn't configured our instance and we had parameters as part of our redirect, it would incorrectly add a `/` to the last parameter in the url.

This also changes such that changing your instance url now won't rely anymore on `history.back()` but instead just redirects to following page.