### PR TITLE
Remove deprecation from supervisor backups

### DIFF
--- a/redirect.json
+++ b/redirect.json
@@ -339,7 +339,6 @@
   {
     "redirect": "supervisor_backups",
     "name": "Supervisor: Backups",
-    "deprecated": true,
     "badge": "Backups",
     "description": "show your Supervisor backups",
     "introduced": "supervisor-2021.08.1"


### PR DESCRIPTION
I removed the deprecated=true from supervisor backups since it's used for the m key in the frontend.