### PR TITLE
Bypass my-panel for OAuth2 callback

### DIFF
--- a/src/entrypoints/my-redirect.ts
+++ b/src/entrypoints/my-redirect.ts
@@ -62,7 +62,10 @@ const render = (showTroubleshooting: boolean) => {
     return;
   }
 
-  const redirectUrl = `${instanceUrl}/_my_redirect/${window.redirect.redirect}${params}`;
+  const redirectUrl =
+    window.redirect.redirect === "oauth"
+      ? `${instanceUrl}/auth/external/callback${params}`
+      : `${instanceUrl}/_my_redirect/${window.redirect.redirect}${params}`;
 
   const openLink = document.querySelector(".open-link") as HTMLElement;
   openLink.outerHTML = `


### PR DESCRIPTION
OAuth2 callback endpoint in Home Assistant does not require authentication. Instead the authentication is contained in the state parameter which will be validated separately.

This PR will bypass the My panel for the OAuth2 callback and directly link to the AOuth2 callback endpoint in Home Assistant. This makes it work for users that do not store their login.

Fixes https://github.com/home-assistant/core/issues/73625

![image](https://user-images.githubusercontent.com/1444314/176765272-b146bbb5-3d13-4c31-b44e-c9821a1f6c0e.png)
