### PR TITLE
Add noreferrer and noopener to sugested HTML

### DIFF
--- a/src/entrypoints/my-create-link.ts
+++ b/src/entrypoints/my-create-link.ts
@@ -254,7 +254,7 @@ ${badgeHTML}</textarea
   }
 
   private _createHTML() {
-    return `<a href="${this._url}" target="_blank"><img src="${
+    return `<a href="${this._url}" target="_blank" rel="noreferrer noopener"><img src="${
       window.location.origin
     }${this._createBadge()}" alt="${this._altText}" /></a>`;
   }


### PR DESCRIPTION
While `noopener` is implied for modern browsers when `target="_blank"` is used, I added this as well for compatibility with legacy browsers.