### PR TITLE
Add 'format' script

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "proseWrap": "always"
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "main": "src/entrypoint.ts",
   "scripts": {
+    "format": "npx prettier -w .",
     "lint:types": "tsc",
     "lint": "yarn run lint:types",
     "test": "node test/badges.js && node test/redirects.js",


### PR DESCRIPTION
Pretty simple change. Added a basic `format` script to `package.json` and then ran it (without any other modifications) with `yarn run format`. If y'all are ok with this change I'd be happy to add a section to the readme in a follow up PR that explains when you should run `format`.

We could also have a pre-commit that rejects changes that aren't `format`ed but I wasn't sure if that was something y'all wanted.