### PR TITLE
Add cors policy header for badges

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[headers]]
+  for = "/badges/*"
+  [headers.values]
+    cross-origin-resource-policy = "cross-origin"


### PR DESCRIPTION
Fixes #531 assuming, and this is a **big** assumption, that the production version of `my.home-assistant.io` uses Netlify. It's not documented anywhere that it _does_ but also not documented anywhere that it _doesn't_ so I gave it a try assuming it does.

# Testing

## Existing

```
curl -I https://my.home-assistant.io/badges/add_matter_device.svg
HTTP/1.1 200 OK
Date: Thu, 24 Apr 2025 01:54:33 GMT
Content-Type: image/svg+xml
Connection: keep-alive
Cache-Control: public,max-age=0,must-revalidate
cache-status: "Netlify Edge"; fwd=miss
etag: W/"0c195aa8984a76631d60479b98e70f73-ssl-df"
vary: Accept-Encoding
x-nf-request-id: 01JSJR1Y1BKENG0SYNM8EC98T5
CF-Cache-Status: EXPIRED
Report-To: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=JrKVv2kpAiObMX0uAliA9%2BmOi4OhEeh6vJzx63GCwynOnG%2FyciWZD8RhnUjFWUhyfpX2QHR5fpWmBcIYg3XqzPsntFZdyE13DsELbIOpWshOdLT0ITmy%2FEsG2UzqyAx188Xifaxf"}],"group":"cf-nel","max_age":604800}
NEL: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
Server: cloudflare
CF-RAY: 9351f92cbd27bfec-ATL
alt-svc: h3=":443"; ma=86400
server-timing: cfL4;desc="?proto=TCP&rtt=20031&min_rtt=20031&rtt_var=10015&sent=6&recv=7&lost=0&retrans=1&sent_bytes=3370&recv_bytes=686&delivery_rate=46700&cwnd=214&unsent_bytes=0&cid=c8a549834679ab10&ts=436&x=0"
```

## Fixed

```
curl -I https://deploy-preview-542--my-home-assistant.netlify.app/badges/add_matter_device.svg
HTTP/1.1 200 OK
Accept-Ranges: bytes
Age: 68
Cache-Control: public,max-age=0,must-revalidate
Cache-Status: "Netlify Edge"; hit
Content-Length: 3014
Content-Type: image/svg+xml
Cross-Origin-Resource-Policy: cross-origin
Date: Thu, 24 Apr 2025 01:53:40 GMT
Etag: "fe651df07e1dd831930824ab476120d6-ssl"
Server: Netlify
Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
X-Nf-Request-Id: 01JSJR0AQ1EZ75FACHKD62XA9J
X-Robots-Tag: noindex
```

Note the new `Cross-Origin-Resource-Policy: cross-origin`.


