### PR TITLE
Omit ? if no params

### DIFF
--- a/src/entrypoints/my-create-link.ts
+++ b/src/entrypoints/my-create-link.ts
@@ -215,7 +215,9 @@ ${badgeHTML}</textarea
 
   private get _url() {
     return `https://my.home-assistant.io/redirect/${this._redirect.redirect}/${
-      this._redirect.params ? `?${createSearchParam(this._paramsValues)}` : ""
+      Object.keys(this._paramsValues).length
+        ? `?${createSearchParam(this._paramsValues)}`
+        : ""
     }`;
   }
 


### PR DESCRIPTION
Links with only optional params would still append a `?` to the final link.

Can be observed at https://my.home-assistant.io/create-link/?redirect=add_matter_device (which shouldn't have params, but fixing that in another PR)

See fix @ https://deploy-preview-549--my-home-assistant.netlify.app/create-link/?redirect=add_matter_device