### PR TITLE
Fix HACS repository redirect URI path

### DIFF
--- a/src/entrypoints/my-redirect.ts
+++ b/src/entrypoints/my-redirect.ts
@@ -65,12 +65,15 @@ const render = (showTroubleshooting: boolean) => {
     return;
   }
 
+  // Compute redirect base path once based on component
+  const redirectBasePath = window.redirect.component === "hacs"
+    ? `/hacs/_my_redirect/${window.redirect.redirect}`
+    : `/_my_redirect/${window.redirect.redirect}`;
+
   const redirectUrl =
     window.redirect.redirect === "oauth"
       ? `${instanceUrl}/auth/external/callback${params}`
-      : window.redirect.component === "hacs"
-        ? `${instanceUrl}/hacs/_my_redirect/${window.redirect.redirect}${params}`
-        : `${instanceUrl}/_my_redirect/${window.redirect.redirect}${params}`;
+      : `${instanceUrl}${redirectBasePath}${params}`;
 
   const openLink = document.querySelector(".open-link") as HTMLElement;
   openLink.outerHTML = `
@@ -98,11 +101,8 @@ const render = (showTroubleshooting: boolean) => {
       error: params.error || "access_denied",
       state: params.state,
     });
-    const redirectPath = window.redirect.component === "hacs"
-      ? `/hacs/_my_redirect/${window.redirect.redirect}`
-      : `/_my_redirect/${window.redirect.redirect}`;
     declineLink.outerHTML = `
-        <a href="${instanceUrl}${redirectPath}?${declineParams}" class='decline-link' rel="noopener">
+        <a href="${instanceUrl}${redirectBasePath}?${declineParams}" class='decline-link' rel="noopener">
           <md-outlined-button>${buttonCaption}</md-outlined-button>
         </a>
       `;

--- a/src/entrypoints/my-redirect.ts
+++ b/src/entrypoints/my-redirect.ts
@@ -68,7 +68,9 @@ const render = (showTroubleshooting: boolean) => {
   const redirectUrl =
     window.redirect.redirect === "oauth"
       ? `${instanceUrl}/auth/external/callback${params}`
-      : `${instanceUrl}/_my_redirect/${window.redirect.redirect}${params}`;
+      : window.redirect.component === "hacs"
+        ? `${instanceUrl}/hacs/_my_redirect/${window.redirect.redirect}${params}`
+        : `${instanceUrl}/_my_redirect/${window.redirect.redirect}${params}`;
 
   const openLink = document.querySelector(".open-link") as HTMLElement;
   openLink.outerHTML = `
@@ -96,8 +98,11 @@ const render = (showTroubleshooting: boolean) => {
       error: params.error || "access_denied",
       state: params.state,
     });
+    const redirectPath = window.redirect.component === "hacs"
+      ? `/hacs/_my_redirect/${window.redirect.redirect}`
+      : `/_my_redirect/${window.redirect.redirect}`;
     declineLink.outerHTML = `
-        <a href="${instanceUrl}/_my_redirect/${window.redirect.redirect}?${declineParams}" class='decline-link' rel="noopener">
+        <a href="${instanceUrl}${redirectPath}?${declineParams}" class='decline-link' rel="noopener">
           <md-outlined-button>${buttonCaption}</md-outlined-button>
         </a>
       `;


### PR DESCRIPTION
## Fix HACS repository redirect URI path

### Problem
When redirecting from a HACS repository, the redirect URI was using `/_my_redirect/` instead of the HACS-specific path `/hacs/_my_redirect/`.

### Solution
Updated the redirect URL construction in `my-redirect.ts` to detect HACS components and use the correct path prefix:
- HACS redirects now use: `/hacs/_my_redirect/{redirect_name}`
- Other redirects continue to use: `/_my_redirect/{redirect_name}`

This applies to both:
- Main redirect URLs
- OAuth decline links

### Changes
- Modified `src/entrypoints/my-redirect.ts`:
  - Added conditional check for `window.redirect.component === "hacs"`
  - Routes HACS components to `/hacs/_my_redirect/` path
  - Maintains backward compatibility for all other redirects

### Testing
1. Visit `http://localhost:3000/redirect/hacs_repository/?owner=hacs&repository=integration&category=integration`
2. Inspect the "Open your Home Assistant instance" button's `href` attribute
3. Verify it contains `/hacs/_my_redirect/hacs_repository` instead of `/_my_redirect/hacs_repository`
4. Test non-HACS redirects to ensure they still use `/_my_redirect/` path

### Related
- Affects the `hacs_repository` redirect defined in `redirect.json`