### PR TITLE
Fix Firefox styling

### DIFF
--- a/src-11ty/faq.html
+++ b/src-11ty/faq.html
@@ -32,12 +32,11 @@ description: Answers to all your questions about My Home Assistant.
 
   .redirects a .badge {
     display: none;
-    align-items: center;
   }
 
   @media all and (min-width: 600px) {
     .redirects a .badge {
-      display: flex;
+      display: inline-block;
     }
   }
 </style>
@@ -112,9 +111,7 @@ description: Answers to all your questions about My Home Assistant.
     title="Introduced in {{ redirect.introduced | version }}."
   >
     {{ redirect.name }}
-    <div class="badge">
-      <img loading="lazy" src="/badges/{{redirect.redirect}}.svg" />
-    </div>
+    <img class="badge" loading="lazy" src="/badges/{{redirect.redirect}}.svg" />
   </a>
   {% endif %} {% endfor %}
 </div>


### PR DESCRIPTION
Remove flex div which doesnt work correctly in Firefox with inferred image size
From this:
<img width="1067" height="801" alt="image" src="https://github.com/user-attachments/assets/c279e740-8053-4927-9882-159bd669c56e" />
to this:
<img width="753" height="467" alt="image" src="https://github.com/user-attachments/assets/fe5d71b7-fa24-4f6d-8097-7a448f637e47" />

Tested in Chrome aswell, has no impact there.