### PR TITLE
Fix typo in my-url-input tag name declaration

### DIFF
--- a/src/components/my-url-input.ts
+++ b/src/components/my-url-input.ts
@@ -102,6 +102,6 @@ export class MyUrlInputMain extends LitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    "my-url-inout": MyUrlInputMain;
+    "my-url-input": MyUrlInputMain;
   }
 }


### PR DESCRIPTION
The `HTMLElementTagNameMap` declaration in `src/components/my-url-input.ts`
registers the element as `"my-url-inout"`, but the component is defined with
`@customElement("my-url-input")` and used as `<my-url-input>` in `my-index.ts`
and `my-change-url.ts`.

This fixes the tag name so TypeScript correctly types DOM queries for
`my-url-input`, and no longer declares a nonexistent `my-url-inout` element.

No runtime change — `yarn test` and `yarn format:check` pass.