### PR TITLE
Fix yarn command typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Or, perform a production build with:
 And then serve it up with:
 
 ```bash
-yard serve dist
+yarn serve dist
 ```
 
 Open http://localhost:3000 to view your production build.


### PR DESCRIPTION
The production build instructions show `yard serve dist`, which fails — there's
no `yard` command. The project uses yarn (`packageManager: yarn@3.6.3`), and
`script/develop` serves the build with `yarn serve dist`. This corrects the
command.