### PR TITLE
Forward dev container port 3000 to match dev server

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,6 @@
   "image": "mcr.microsoft.com/vscode/devcontainers/typescript-node:22",
   "postCreateCommand": "yarn install",
   "context": "..",
-  "appPort": 5000,
+  "appPort": 3000,
   "extensions": ["esbenp.prettier-vscode"]
 }


### PR DESCRIPTION
The dev container forwards `appPort` 5000, but the dev server (`yarn serve dist` via `script/develop`) listens on port 3000 — serve v14's default — and the README says to open http://localhost:3000. This updates `appPort` so the correct port is forwarded.