### PR TITLE
Fix broken FAQ link on the homepage

### DIFF
--- a/src-11ty/index.html
+++ b/src-11ty/index.html
@@ -41,7 +41,7 @@ description: Link to specific pages in your Home Assistant instance.
 <h1 class="card-header">My Home Assistant</h1>
 <div class="card-content">
   My Home Assistant allows the documentation to link you to specific pages in
-  your Home Assistant instance. See <a href="faq.html">the FAQ</a> for more
+  your Home Assistant instance. See <a href="/faq/">the FAQ</a> for more
   information.
 </div>
 


### PR DESCRIPTION
The homepage links to `faq.html`, but Eleventy builds the FAQ page to `/faq/`, so the link 404s on the built site. The footer and other internal links already use `/faq/`. This points the homepage link to `/faq/` as well. Verified with a production build: the built homepage now links to `/faq/`, which resolves to the generated `dist/faq/index.html`.