### PR TITLE
Fix copy button getting stuck on "Copied!"

### DIFF
--- a/src/entrypoints/my-create-link.ts
+++ b/src/entrypoints/my-create-link.ts
@@ -252,6 +252,12 @@ ${badgeHTML}</textarea
   }
 
   private _copySuccess(element: MdOutlinedButton) {
+    // Ignore repeat clicks while the "Copied!" feedback is still showing,
+    // otherwise the transient label is captured as prevText and restored,
+    // leaving the button permanently stuck on "Copied!".
+    if (element.classList.contains("success")) {
+      return;
+    }
     const prevText = element.innerText;
     element.classList.add("success");
     element.innerText = "Copied!";


### PR DESCRIPTION
Clicking one of the Copy buttons on the create-link page (Copy URL / Copy Markdown / Copy HTML) twice within one second leaves the button label
permanently stuck on "Copied!" until the page is reloaded.

`_copySuccess` saves the button's current label, sets it to "Copied!", then restores the saved label after 1 second. A second click during that window
saves the already-changed "Copied!" label and schedules another restore back to "Copied!", so the original label is lost.

This adds a guard that ignores repeat clicks while the "Copied!" feedback is still showing. The copy itself still happens on every click — only the
redundant label animation is skipped.
