### PR TITLE
Stop rejecting valid URLs when creating links

### DIFF
--- a/src/entrypoints/my-create-link.ts
+++ b/src/entrypoints/my-create-link.ts
@@ -202,7 +202,12 @@ ${badgeHTML}</textarea
     const paramType = this._redirect.params![key];
 
     if (paramType.startsWith("url")) {
-      value = decodeURI(value);
+      try {
+        value = decodeURI(value);
+      } catch (err) {
+        // Malformed escape sequence (e.g. a lone "%"); keep the value as
+        // typed and let validateParam judge it.
+      }
     }
 
     const validationMessage = validateParam(paramType, value);

--- a/src/util/validate.ts
+++ b/src/util/validate.ts
@@ -6,14 +6,25 @@ const validateUrl = (value: string) => {
     return "Please enter your full URL, including the protocol part (https://).";
   }
   try {
-    new URL(value);
+    if (!["http:", "https:"].includes(new URL(value).protocol)) {
+      return "Invalid URL.";
+    }
   } catch (err) {
     return "Invalid URL.";
   }
-  if (
-    (decodeURI(value) === value ? encodeURI(value) : value) !==
-    sanitizeUrl(value)
-  ) {
+  // Reject characters that URL parsers strip or handle inconsistently
+  // (surrounding whitespace, control characters, backslashes): the raw value
+  // is what gets forwarded, so it must not differ from the URL that was
+  // validated.
+  if (value !== value.trim() || /[\t\n\r\\]/.test(value)) {
+    return "Invalid URL.";
+  }
+  // sanitize-url returns "about:blank" for URLs it considers unsafe
+  // (e.g. javascript:, data:, vbscript:). We can't compare its output to the
+  // input directly, because sanitize-url also normalizes safe URLs (adds a
+  // trailing slash, lowercases the host, punycodes IDNs, ...), which would
+  // reject valid input.
+  if (sanitizeUrl(value) === "about:blank") {
     return "Invalid URL.";
   }
   return undefined;


### PR DESCRIPTION
The URL fields on the create-link page reject a lot of perfectly valid URLs with "Invalid URL." — for example `https://example.com` (no trailing slash), `https://example.com?a=b`, or a URL with an uppercase host. The same thing happens when following a shared link that has a `url`-type parameter (`blueprint_url`, `repository_url`) in one of these forms: you get an "Invalid parameters" alert instead of being redirected.

The cause is in `validateUrl`, which compares the input string against `sanitizeUrl(value)`. Since @braintree/sanitize-url 7.1.0, `sanitizeUrl` normalizes http/https URLs through `new URL().toString()` — it adds a trailing slash to an empty path, lowercases the host, punycodes internationalized domains — so the equality check fails for any valid URL that isn't already in normalized form.

This replaces the comparison with explicit checks that keep everything the old check was actually protecting against:

- only `http:`/`https:` URLs pass (previously e.g. `ftp:` slipped through)
- URLs with surrounding whitespace, control characters, or backslashes are rejected, since URL parsers strip or disagree on those characters and the raw value is what gets forwarded
- sanitize-url is still used to reject anything it flags as unsafe (`javascript:`, `data:`, `vbscript:`, including encoded variants)

While testing this I also hit an uncaught `URIError` in the create-link input handler: `decodeURI` throws on every keystroke once a URL field contains a malformed escape like a lone `%`. That call is now guarded, and validation handles the raw value fine.

Tested against the pinned sanitize-url 7.1.2 with a set of valid, malformed, and obfuscated-scheme URLs: the examples above now pass, and all the unsafe-scheme variants are still rejected.