### PR TITLE
Run lint and production build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,5 +28,5 @@ jobs:
       - run: yarn install --immutable
       - run: yarn run lint
       - run: ./script/build
-      - run: npm test
-      - run: npm run format:check
+      - run: yarn test
+      - run: yarn run format:check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           node-version-file: ".nvmrc"
           cache: yarn
       - run: yarn install --immutable
-      - run: yarn run lint
-      - run: ./script/build
+      - run: yarn lint
+      - run: yarn build
       - run: yarn test
-      - run: yarn run format:check
+      - run: yarn format:check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@
 # - build the source code
 # - run tests
 # - ensure the code is formatted
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+# For more information see: https://docs.github.com/en/actions/tutorials/build-and-test-code/nodejs
 
 name: CI
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 # This workflow will:
 # - do a clean install of node dependencies
+# - lint the source code
 # - build the source code
-# - run tests across different versions of node
+# - run tests
 # - ensure the code is formatted
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
@@ -25,5 +26,7 @@ jobs:
           node-version-file: ".nvmrc"
           cache: yarn
       - run: yarn install --immutable
+      - run: yarn run lint
+      - run: ./script/build
       - run: npm test
       - run: npm run format:check

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ yarn build
 And then serve it up with:
 
 ```bash
-yard serve dist
+yarn serve dist
 ```
 
 Open http://localhost:3000 to view your production build.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Open http://localhost:3000 to view your changes as you make them.
 Or, perform a production build with:
 
 ```bash
-./script/build
+yarn build
 ```
 
 And then serve it up with:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Powers https://my.home-assistant.io/
 Start a hot-reloading development build server with:
 
 ```bash
-./script/develop
+yarn develop
 ```
 
 Open http://localhost:3000 to view your changes as you make them.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "src/entrypoint.ts",
   "scripts": {
-    "build": "sh ./script/build",
+    "build": "./script/build",
     "format": "npx prettier -w .",
     "format:check": "npx prettier --list-different .",
     "lint": "yarn lint:types",

--- a/package.json
+++ b/package.json
@@ -6,12 +6,13 @@
   "main": "src/entrypoint.ts",
   "scripts": {
     "build": "./script/build",
-    "format": "npx prettier -w .",
-    "format:check": "npx prettier --list-different .",
+    "develop": "./script/develop",
+    "format": "prettier -w .",
+    "format:check": "prettier --list-different .",
     "lint": "yarn lint:types",
     "lint:types": "tsc",
     "precommit-badges": "node build-scripts/create-badges.js && git add public/badges",
-    "precommit-redirect": "node build-scripts/sort-redirects.js && npx prettier -w redirect.json && git add redirect.json",
+    "precommit-redirect": "node build-scripts/sort-redirects.js && prettier -w redirect.json && git add redirect.json",
     "test": "node test/badges.js && node test/redirects.js"
   },
   "pre-commit": [

--- a/package.json
+++ b/package.json
@@ -5,13 +5,14 @@
   "type": "module",
   "main": "src/entrypoint.ts",
   "scripts": {
+    "build": "sh ./script/build",
     "format": "npx prettier -w .",
     "format:check": "npx prettier --list-different .",
+    "lint": "yarn lint:types",
     "lint:types": "tsc",
-    "lint": "yarn run lint:types",
-    "test": "node test/badges.js && node test/redirects.js",
+    "precommit-badges": "node build-scripts/create-badges.js && git add public/badges",
     "precommit-redirect": "node build-scripts/sort-redirects.js && npx prettier -w redirect.json && git add redirect.json",
-    "precommit-badges": "node build-scripts/create-badges.js && git add public/badges"
+    "test": "node test/badges.js && node test/redirects.js"
   },
   "pre-commit": [
     "precommit-redirect",

--- a/script/build
+++ b/script/build
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 # Stop on errors
 set -e
 

--- a/script/develop
+++ b/script/develop
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 # Stop on errors
 set -e
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es2017",
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "lib": ["es2017", "dom", "dom.iterable"],
     "noEmit": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
The CI workflow said it built the site, but it only installed dependencies, ran tests, and checked formatting. This adds the existing TypeScript lint check and the production build so compiler and bundling failures are caught before merging.

TypeScript 6 also made the existing lint command fail because `moduleResolution: "node"` selects the deprecated Node 10 resolver. Since this is a browser application bundled with Rollup, this switches TypeScript to `moduleResolution: "bundler"` rather than suppressing the deprecation.

The local commands now match CI: `yarn lint`, `yarn build`, `yarn test`, and `yarn format:check`. The build and development scripts have proper shebangs and are available as `yarn build` and `yarn develop`.

Tested with:

- `yarn lint`
- `yarn test`
- `yarn format:check`
- `yarn build`
- `yarn develop` with an HTTP request confirming the expected page is served